### PR TITLE
Add functionality to retrieve most discussed topics by person ID

### DIFF
--- a/src/TheLsmArchive.ApiClient/Services/Abstractions/ILsmArchiveClientService.cs
+++ b/src/TheLsmArchive.ApiClient/Services/Abstractions/ILsmArchiveClientService.cs
@@ -29,6 +29,16 @@ public interface ILsmArchiveClientService
         CancellationToken cancellationToken);
 
     /// <summary>
+    /// Gets the most discussed topics associated with a person by their ID.
+    /// </summary>
+    /// <param name="personId">The person ID.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>The <see cref="Result{T}"/> of <see cref="List{T}"/> of <see cref="MostDiscussedTopic"/>.</returns>
+    public Task<Result<List<MostDiscussedTopic>>> GetMostDiscussedTopicsByPersonId(
+        int personId,
+        CancellationToken cancellationToken);
+
+    /// <summary>
     /// Gets topics associated with a person by their ID.
     /// </summary>
     /// <param name="personId">The person ID.</param>

--- a/src/TheLsmArchive.ApiClient/Services/LsmArchiveClientService.cs
+++ b/src/TheLsmArchive.ApiClient/Services/LsmArchiveClientService.cs
@@ -89,6 +89,25 @@ public class LsmArchiveClientService : ILsmArchiveClientService
 
     /// <inheritdoc />
     /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="personId"/> is negative.</exception>
+    public Task<Result<List<MostDiscussedTopic>>> GetMostDiscussedTopicsByPersonId(
+        int personId,
+        CancellationToken cancellationToken)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegative(personId);
+
+        _logger.LogInformation("Getting most discussed topics for person with ID: {PersonId}", personId);
+
+        HttpRequestMessage requestMessage = BuildGetRequestMessageFor($"{PersonRoute}/{personId}/topics/most-discussed");
+
+        return ExecuteRequestAsync<List<MostDiscussedTopic>>(
+            requestMessage,
+            hasContent: result => result is not null && result.Count > 0,
+            cancellationToken
+        );
+    }
+
+    /// <inheritdoc />
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="personId"/> is negative.</exception>
     public Task<Result<PersonDetails>> GetPersonDetailsById(int personId, CancellationToken cancellationToken)
     {
         ArgumentOutOfRangeException.ThrowIfNegative(personId);

--- a/src/TheLsmArchive.Models/Response/MostDiscussedTopic.cs
+++ b/src/TheLsmArchive.Models/Response/MostDiscussedTopic.cs
@@ -1,0 +1,12 @@
+namespace TheLsmArchive.Models.Response;
+
+/// <summary>
+/// Represents a topic ranked by how often it appears alongside a person in episodes.
+/// </summary>
+/// <param name="Id">The topic ID.</param>
+/// <param name="Name">The topic name.</param>
+/// <param name="EpisodeCount">The number of episodes where the person and topic co-occur.</param>
+public record MostDiscussedTopic(
+    int Id,
+    string Name,
+    int EpisodeCount);

--- a/src/TheLsmArchive.Web.Api/Features/Persons/PersonEndpoints.cs
+++ b/src/TheLsmArchive.Web.Api/Features/Persons/PersonEndpoints.cs
@@ -41,6 +41,13 @@ internal static class PersonEndpoints
                 .Produces<Ok<PagedResponse<Topic>>>()
                 .Produces<BadRequest>();
 
+            person.MapGet("/{id:int}/topics/most-discussed", GetMostDiscussedTopicsByPersonId)
+                .WithName(nameof(GetMostDiscussedTopicsByPersonId))
+                .WithSummary("Gets the most discussed topics for a specific person.")
+                .WithDescription("Retrieves the top 25 topics ranked by the number of episodes in which the specified person and topic appear together.")
+                .Produces<Ok<List<MostDiscussedTopic>>>()
+                .Produces<BadRequest>();
+
             person.MapGet("/{id:int}/episodes", GetEpisodesByPersonId)
                 .WithName(nameof(GetEpisodesByPersonId))
                 .WithSummary("Gets episodes associated with a specific person.")
@@ -95,6 +102,15 @@ internal static class PersonEndpoints
         CancellationToken cancellationToken)
     {
         PagedResponse<Topic> topics = await topicService.GetByPersonId(id, pagedRequest, cancellationToken);
+        return TypedResults.Ok(topics);
+    }
+
+    private static async Task<Ok<List<MostDiscussedTopic>>> GetMostDiscussedTopicsByPersonId(
+        [FromRoute] int id,
+        [FromServices] ITopicService topicService,
+        CancellationToken cancellationToken)
+    {
+        List<MostDiscussedTopic> topics = await topicService.GetMostDiscussedByPersonId(id, cancellationToken);
         return TypedResults.Ok(topics);
     }
 

--- a/src/TheLsmArchive.Web.Api/Features/Topics/ITopicService.cs
+++ b/src/TheLsmArchive.Web.Api/Features/Topics/ITopicService.cs
@@ -48,6 +48,16 @@ public interface ITopicService
          CancellationToken cancellationToken);
 
     /// <summary>
+    /// Gets the most discussed topics for a person's identifier.
+    /// </summary>
+    /// <param name="id">The person identifier.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>The top discussed topics associated with the person.</returns>
+    public Task<List<MostDiscussedTopic>> GetMostDiscussedByPersonId(
+        int id,
+        CancellationToken cancellationToken);
+
+    /// <summary>
     /// Gets topics by a person's identifier.
     /// </summary>
     /// <param name="id">The person identifier.</param>

--- a/src/TheLsmArchive.Web.Api/Features/Topics/TopicService.cs
+++ b/src/TheLsmArchive.Web.Api/Features/Topics/TopicService.cs
@@ -106,6 +106,40 @@ public sealed class TopicService : ITopicService
 
     /// <inheritdoc />
     /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="id"/> is negative or zero.</exception>
+    public Task<List<MostDiscussedTopic>> GetMostDiscussedByPersonId(
+        int id,
+        CancellationToken cancellationToken)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(id);
+
+        _logger.LogInformation("Getting most discussed topics for person with ID: {Id}", id);
+
+        const int mostDiscussedTopicCount = 25;
+
+        return _dbContext.PersonEpisodes
+            .Where(personEpisode => personEpisode.PersonId == id)
+            .Join(
+                _dbContext.TopicEpisodes,
+                personEpisode => personEpisode.EpisodeId,
+                topicEpisode => topicEpisode.EpisodeId,
+                (_, topicEpisode) => new
+                {
+                    topicEpisode.TopicId,
+                    topicEpisode.Topic.Name
+                })
+            .GroupBy(topic => new { topic.TopicId, topic.Name })
+            .OrderByDescending(group => group.Count())
+            .ThenBy(group => group.Key.Name)
+            .Take(mostDiscussedTopicCount)
+            .Select(group => new MostDiscussedTopic(
+                group.Key.TopicId,
+                group.Key.Name,
+                group.Count()))
+            .ToListAsync(cancellationToken);
+    }
+
+    /// <inheritdoc />
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="id"/> is negative or zero.</exception>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="pagedRequest"/> is null.</exception>
     public async Task<PagedResponse<Episode>> GetEpisodesByTopicId(
         int id,

--- a/src/TheLsmArchive.Web.Frontend/Pages/PersonPage.razor
+++ b/src/TheLsmArchive.Web.Frontend/Pages/PersonPage.razor
@@ -92,59 +92,125 @@
 
         <MudItem xs="12">
             <SectionHeader Icon="@Icons.Material.Filled.Tag" Color="Color.Tertiary" Title="Topics" />
-            <MudTextField
-                T="string"
-                Variant="Variant.Outlined"
-                Placeholder="Search topics..."
-                Adornment="Adornment.Start"
-                AdornmentIcon="@Icons.Material.Filled.Search"
-                AdornmentColor="Color.Tertiary"
-                Value="_topicSearchTerm"
-                ValueChanged="OnTopicSearchTermChanged"
-                Immediate="true"
-                FullWidth="true"
-                Clearable="true"
-                Margin="Margin.Dense"
-                Class="mb-4" />
-            @if (_isLoadingTopics)
-            {
-                <MudProgressLinear Color="Color.Tertiary" Indeterminate="true" Class="mb-4" />
-            }
-            @if (_topicsResponse is { Items.Count: > 0 })
-            {
-                <MudGrid Spacing="3">
-                    @foreach (var topic in _topicsResponse.Items)
+            <MudTabs Rounded="true"
+                     Outlined="true"
+                     Border="true"
+                     Centered="true"
+                     KeepPanelsAlive="true"
+                     ApplyEffectsToContainer="true"
+                     Elevation="1"
+                     Color="Color.Default"
+                     HideSlider="true"
+                     TabHeaderClass="topics-tab-header"
+                     TabButtonsClass="topics-tab-button"
+                     ActiveTabClass="topics-tab-active"
+                     ActivePanelIndex="@_activeTopicsTabIndex"
+                     ActivePanelIndexChanged="@(index => _activeTopicsTabIndex = index)"
+                     TabPanelsClass="pa-4">
+                <MudTabPanel Text="Most Discussed" Icon="@Icons.Material.Filled.TrendingUp">
+                    @if (_mostDiscussedTopics is { Count: > 0 })
                     {
-                        <MudItem xs="12" sm="6" md="4" lg="3" Class="d-flex">
-                            <TopicCard Topic="topic" />
-                        </MudItem>
+                        <MudGrid Spacing="2">
+                            @for (int index = 0; index < _mostDiscussedTopics.Count; index++)
+                            {
+                                var topic = _mostDiscussedTopics[index];
+                                var rank = index + 1;
+
+                                <MudItem xs="12" md="6">
+                                    <MudPaper Class="pa-4 h-100 entity-card card-hover hover-tertiary clickable-card" Elevation="1"
+                                              @onclick='@(() => NavigationManager.NavigateTo($"/Topic/{topic.Id}"))'>
+                                        <MudStack Row="true" Justify="Justify.SpaceBetween" AlignItems="AlignItems.Center" Spacing="2">
+                                            <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2">
+                                                <MudChip T="string"
+                                                         Color="Color.Tertiary"
+                                                         Variant="Variant.Outlined"
+                                                         Size="Size.Small">
+                                                    #@rank
+                                                </MudChip>
+                                                <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="1">
+                                                    <MudIcon Icon="@Icons.Material.Filled.Tag" Color="Color.Tertiary" Size="Size.Small" />
+                                                    <MudText Typo="Typo.body1" Class="fw-bold">@topic.Name</MudText>
+                                                </MudStack>
+                                            </MudStack>
+                                            <MudChip T="string"
+                                                     Color="Color.Tertiary"
+                                                     Variant="Variant.Outlined"
+                                                     Icon="@Icons.Material.Filled.Forum">
+                                                @(topic.EpisodeCount == 1 ? "1 episode" : $"{topic.EpisodeCount} episodes")
+                                            </MudChip>
+                                        </MudStack>
+                                    </MudPaper>
+                                </MudItem>
+                            }
+                        </MudGrid>
                     }
-                </MudGrid>
-                @if (_topicsResponse.TotalPages > 1)
-                {
-                    <MudStack Row="true" Justify="Justify.Center" Class="mt-4">
-                        <MudPagination Count="@_topicsResponse.TotalPages"
-                                       Selected="@_currentTopicPage"
-                                       SelectedChanged="OnTopicPageChanged"
-                                       Variant="Variant.Outlined"
-                                       Color="Color.Primary"
-                                       BoundaryCount="1"
-                                       MiddleCount="3"
-                                       ShowFirstButton="true"
-                                       ShowLastButton="true" />
-                    </MudStack>
-                }
-            }
-            else if (_topicsResponse is not null)
-            {
-                <MudText Typo="Typo.body2" Class="mt-2" Style="opacity: 0.6;">No topics found.</MudText>
-            }
-            else
-            {
-                <MudContainer Class="d-flex justify-center py-4">
-                    <MudProgressCircular Indeterminate="true" Color="Color.Primary" Size="Size.Small" />
-                </MudContainer>
-            }
+                    else if (_mostDiscussedTopics is not null)
+                    {
+                        <MudText Typo="Typo.body2" Style="opacity: 0.6;">No ranked topics available yet.</MudText>
+                    }
+                    else
+                    {
+                        <MudContainer Class="d-flex justify-center py-4">
+                            <MudProgressCircular Indeterminate="true" Color="Color.Tertiary" Size="Size.Small" />
+                        </MudContainer>
+                    }
+                </MudTabPanel>
+                <MudTabPanel Text="All" Icon="@Icons.Material.Filled.ViewAgenda">
+                    <MudTextField
+                        T="string"
+                        Variant="Variant.Outlined"
+                        Placeholder="Search topics..."
+                        Adornment="Adornment.Start"
+                        AdornmentIcon="@Icons.Material.Filled.Search"
+                        AdornmentColor="Color.Tertiary"
+                        Value="_topicSearchTerm"
+                        ValueChanged="OnTopicSearchTermChanged"
+                        Immediate="true"
+                        FullWidth="true"
+                        Clearable="true"
+                        Margin="Margin.Dense"
+                        Class="mb-4" />
+                    @if (_isLoadingTopics)
+                    {
+                        <MudProgressLinear Color="Color.Tertiary" Indeterminate="true" Class="mb-4" />
+                    }
+                    @if (_topicsResponse is { Items.Count: > 0 })
+                    {
+                        <MudGrid Spacing="3">
+                            @foreach (var topic in _topicsResponse.Items)
+                            {
+                                <MudItem xs="12" sm="6" md="4" lg="3" Class="d-flex">
+                                    <TopicCard Topic="topic" />
+                                </MudItem>
+                            }
+                        </MudGrid>
+                        @if (_topicsResponse.TotalPages > 1)
+                        {
+                            <MudStack Row="true" Justify="Justify.Center" Class="mt-4">
+                                <MudPagination Count="@_topicsResponse.TotalPages"
+                                               Selected="@_currentTopicPage"
+                                               SelectedChanged="OnTopicPageChanged"
+                                               Variant="Variant.Outlined"
+                                               Color="Color.Primary"
+                                               BoundaryCount="1"
+                                               MiddleCount="3"
+                                               ShowFirstButton="true"
+                                               ShowLastButton="true" />
+                            </MudStack>
+                        }
+                    }
+                    else if (_topicsResponse is not null)
+                    {
+                        <MudText Typo="Typo.body2" Class="mt-2" Style="opacity: 0.6;">No topics found.</MudText>
+                    }
+                    else
+                    {
+                        <MudContainer Class="d-flex justify-center py-4">
+                            <MudProgressCircular Indeterminate="true" Color="Color.Primary" Size="Size.Small" />
+                        </MudContainer>
+                    }
+                </MudTabPanel>
+            </MudTabs>
         </MudItem>
 
         <MudItem xs="12">
@@ -220,6 +286,7 @@
 @code {
     private const int PageSize = 50;
     private const int SearchDebounceMs = 350;
+    private const int MostDiscussedTopicsTabIndex = 0;
 
     [Parameter]
     public int Id { get; set; }
@@ -227,8 +294,10 @@
     private Person? _person;
     private PersonDetails? _personDetails;
     private Episode? _latestEpisode;
+    private List<MostDiscussedTopic>? _mostDiscussedTopics;
     private PagedResponse<Topic>? _topicsResponse;
     private PagedResponse<Episode>? _episodesResponse;
+    private int _activeTopicsTabIndex = MostDiscussedTopicsTabIndex;
     private int _currentTopicPage = 1;
     private int _currentEpisodePage = 1;
     private string _topicSearchTerm = string.Empty;
@@ -248,10 +317,17 @@
         var getPersonTask = GetPerson(cts.Token);
         var getPersonDetailsTask = GetPersonDetails(cts.Token);
         var getLatestEpisodeTask = GetLatestEpisode(cts.Token);
+        var getMostDiscussedTopicsTask = GetMostDiscussedTopics(cts.Token);
         var getPersonTopicsTask = GetPersonTopics(_currentTopicPage, cts.Token);
         var getPersonEpisodesTask = GetPersonEpisodes(_currentEpisodePage, cts.Token);
 
-        await Task.WhenAll(getPersonTask, getPersonDetailsTask, getLatestEpisodeTask, getPersonTopicsTask, getPersonEpisodesTask);
+        await Task.WhenAll(
+            getPersonTask,
+            getPersonDetailsTask,
+            getLatestEpisodeTask,
+            getMostDiscussedTopicsTask,
+            getPersonTopicsTask,
+            getPersonEpisodesTask);
     }
 
     private async Task OnTopicSearchTermChanged(string value)
@@ -332,7 +408,6 @@
             },
             () =>
             {
-                // TODO Figure out how to handle no content (e.g., show a "not found" message)
                 Logger.LogWarning("No person found with ID {Id}.", Id);
                 return Task.CompletedTask;
             });
@@ -351,7 +426,6 @@
             },
             () =>
             {
-                // TODO Figure out how to handle no content (e.g., show a "not found" message)
                 Logger.LogWarning("No person details found for person ID {Id}.", Id);
                 return Task.CompletedTask;
             });
@@ -391,6 +465,24 @@
             () =>
             {
                 _topicsResponse = new PagedResponse<Topic>([], 0, pageNumber, PageSize);
+                return Task.CompletedTask;
+            });
+    }
+
+    private async Task GetMostDiscussedTopics(CancellationToken cancellationToken)
+    {
+        var mostDiscussedTopicsResult = await ClientService.GetMostDiscussedTopicsByPersonId(Id, cancellationToken);
+
+        await HandleResult(
+            mostDiscussedTopicsResult,
+            topics =>
+            {
+                _mostDiscussedTopics = topics;
+                return Task.CompletedTask;
+            },
+            () =>
+            {
+                _mostDiscussedTopics = [];
                 return Task.CompletedTask;
             });
     }

--- a/tests/TheLsmArchive.ApiClient.Tests/LsmArchiveClientServiceTests.cs
+++ b/tests/TheLsmArchive.ApiClient.Tests/LsmArchiveClientServiceTests.cs
@@ -214,6 +214,44 @@ public class LsmArchiveClientServiceTests
     }
 
     [Fact]
+    public async Task GetMostDiscussedTopicsByPersonId_WithNegativeId_Throws()
+    {
+        using MockHandler handler = new("{}");
+        LsmArchiveClientService service = CreateService(handler);
+
+        await Assert.ThrowsAsync<ArgumentOutOfRangeException>(
+            () => service.GetMostDiscussedTopicsByPersonId(-1, CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task GetMostDiscussedTopicsByPersonId_WithResults_ReturnsSuccess()
+    {
+        var response = new[]
+        {
+            new { id = 1, name = "Topic A", episodeCount = 3 }
+        };
+        using MockHandler handler = new(JsonSerializer.Serialize(response));
+        LsmArchiveClientService service = CreateService(handler);
+
+        Result<List<MostDiscussedTopic>> result = await service.GetMostDiscussedTopicsByPersonId(1, CancellationToken.None);
+
+        Result<List<MostDiscussedTopic>>.Success success = Assert.IsType<Result<List<MostDiscussedTopic>>.Success>(result);
+        Assert.Single(success.Data);
+        Assert.Equal(3, success.Data[0].EpisodeCount);
+    }
+
+    [Fact]
+    public async Task GetMostDiscussedTopicsByPersonId_WithEmptyItems_ReturnsNoContent()
+    {
+        using MockHandler handler = new(JsonSerializer.Serialize(Array.Empty<object>()));
+        LsmArchiveClientService service = CreateService(handler);
+
+        Result<List<MostDiscussedTopic>> result = await service.GetMostDiscussedTopicsByPersonId(1, CancellationToken.None);
+
+        Assert.IsType<Result<List<MostDiscussedTopic>>.NoContent>(result);
+    }
+
+    [Fact]
     public async Task GetEpisodesByPersonId_WithNegativeId_Throws()
     {
         using MockHandler handler = new("{}");
@@ -342,6 +380,23 @@ public class LsmArchiveClientServiceTests
         Assert.NotNull(handler.LastRequest);
         string uri = handler.LastRequest.RequestUri!.ToString();
         Assert.Equal("https://api.test.com/topic/7/episodes?pageNumber=2&pageSize=10&searchTerm=gaming", uri);
+    }
+
+    [Fact]
+    public async Task GetMostDiscussedTopicsByPersonId_SetsCorrectRequestUri()
+    {
+        var response = new[]
+        {
+            new { id = 1, name = "Topic A", episodeCount = 2 }
+        };
+        using CapturingHandler handler = new(JsonSerializer.Serialize(response));
+        HttpClient httpClient = new(handler) { BaseAddress = new Uri("https://api.test.com/") };
+        LsmArchiveClientService service = new(_loggerMock.Object, httpClient);
+
+        await service.GetMostDiscussedTopicsByPersonId(7, CancellationToken.None);
+
+        Assert.NotNull(handler.LastRequest);
+        Assert.Equal("https://api.test.com/person/7/topics/most-discussed", handler.LastRequest.RequestUri!.ToString());
     }
 
     private sealed class MockHandler : HttpMessageHandler

--- a/tests/TheLsmArchive.Web.Api.Tests/Features/Persons/PersonEndpointTests.cs
+++ b/tests/TheLsmArchive.Web.Api.Tests/Features/Persons/PersonEndpointTests.cs
@@ -123,6 +123,22 @@ public class PersonEndpointTests : IClassFixture<CustomWebApplicationFactory>
     }
 
     [Fact]
+    public async Task GetMostDiscussedTopicsByPersonId_ReturnsOk()
+    {
+        // Arrange
+        List<MostDiscussedTopic> expected = [new(1, "Topic A", 3)];
+        _factory.TopicServiceMock
+            .Setup(s => s.GetMostDiscussedByPersonId(1, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(expected);
+
+        // Act
+        HttpResponseMessage response = await _client.GetAsync("/person/1/topics/most-discussed");
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    [Fact]
     public async Task GetEpisodesByPersonId_ReturnsOk()
     {
         // Arrange

--- a/tests/TheLsmArchive.Web.Api.Tests/Features/Topics/TopicServiceTests.cs
+++ b/tests/TheLsmArchive.Web.Api.Tests/Features/Topics/TopicServiceTests.cs
@@ -439,6 +439,97 @@ public class TopicServiceTests : BaseServiceIntegrationTest, IClassFixture<Servi
 
     #endregion
 
+    #region GetMostDiscussedByPersonId
+
+    [Theory]
+    [InlineData(-1)]
+    [InlineData(0)]
+    public async Task GetMostDiscussedByPersonId_WithInvalidId_ThrowsArgumentOutOfRangeException(int id)
+    {
+#pragma warning disable IDE0022
+        await Assert.ThrowsAsync<ArgumentOutOfRangeException>(() =>
+            _topicService.GetMostDiscussedByPersonId(id, TestContext.Current.CancellationToken));
+#pragma warning restore IDE0022
+    }
+
+    [Fact]
+    public async Task GetMostDiscussedByPersonId_WithAssociatedTopics_ReturnsRankedTopics()
+    {
+        // Arrange
+        ShowEntity show = new() { Name = "Show 1" };
+        await InsertSingleInstanceOfEntityAsync(show);
+
+        PersonEntity person = new() { Name = "Test Person", NormalizedName = "testperson" };
+        await InsertSingleInstanceOfEntityAsync(person);
+
+        TopicEntity alpha = new() { Name = "Alpha Topic", NormalizedName = "alphatopic" };
+        TopicEntity beta = new() { Name = "Beta Topic", NormalizedName = "betatopic" };
+        TopicEntity gamma = new() { Name = "Gamma Topic", NormalizedName = "gammatopic" };
+        await InsertSingleInstanceOfEntityAsync(alpha);
+        await InsertSingleInstanceOfEntityAsync(beta);
+        await InsertSingleInstanceOfEntityAsync(gamma);
+
+        EpisodeEntity episode1 = await CreateEpisodeAsync(show.Id, 7001, "Episode A");
+        EpisodeEntity episode2 = await CreateEpisodeAsync(show.Id, 7002, "Episode B");
+        EpisodeEntity episode3 = await CreateEpisodeAsync(show.Id, 7003, "Episode C");
+
+        await InsertSingleInstanceOfEntityAsync(new PersonEpisodeEntity { PersonId = person.Id, EpisodeId = episode1.Id });
+        await InsertSingleInstanceOfEntityAsync(new PersonEpisodeEntity { PersonId = person.Id, EpisodeId = episode2.Id });
+        await InsertSingleInstanceOfEntityAsync(new PersonEpisodeEntity { PersonId = person.Id, EpisodeId = episode3.Id });
+
+        await InsertSingleInstanceOfEntityAsync(new TopicEpisodeEntity { TopicId = alpha.Id, EpisodeId = episode1.Id });
+        await InsertSingleInstanceOfEntityAsync(new TopicEpisodeEntity { TopicId = alpha.Id, EpisodeId = episode2.Id });
+        await InsertSingleInstanceOfEntityAsync(new TopicEpisodeEntity { TopicId = beta.Id, EpisodeId = episode1.Id });
+        await InsertSingleInstanceOfEntityAsync(new TopicEpisodeEntity { TopicId = gamma.Id, EpisodeId = episode3.Id });
+
+        // Act
+        List<MostDiscussedTopic> result = await _topicService.GetMostDiscussedByPersonId(
+            person.Id,
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(3, result.Count);
+        Assert.Equal("Alpha Topic", result[0].Name);
+        Assert.Equal(2, result[0].EpisodeCount);
+        Assert.Equal("Beta Topic", result[1].Name);
+        Assert.Equal(1, result[1].EpisodeCount);
+        Assert.Equal("Gamma Topic", result[2].Name);
+        Assert.Equal(1, result[2].EpisodeCount);
+    }
+
+    [Fact]
+    public async Task GetMostDiscussedByPersonId_WithMoreThanTwentyFiveTopics_ReturnsTopTwentyFive()
+    {
+        // Arrange
+        ShowEntity show = new() { Name = "Show 1" };
+        await InsertSingleInstanceOfEntityAsync(show);
+
+        PersonEntity person = new() { Name = "Test Person", NormalizedName = "testperson" };
+        await InsertSingleInstanceOfEntityAsync(person);
+
+        for (int index = 1; index <= 26; index++)
+        {
+            TopicEntity topic = new() { Name = $"Topic {index:D2}", NormalizedName = $"topic{index:D2}" };
+            await InsertSingleInstanceOfEntityAsync(topic);
+
+            EpisodeEntity episode = await CreateEpisodeAsync(show.Id, 7100 + index, $"Episode {index:D2}");
+
+            await InsertSingleInstanceOfEntityAsync(new PersonEpisodeEntity { PersonId = person.Id, EpisodeId = episode.Id });
+            await InsertSingleInstanceOfEntityAsync(new TopicEpisodeEntity { TopicId = topic.Id, EpisodeId = episode.Id });
+        }
+
+        // Act
+        List<MostDiscussedTopic> result = await _topicService.GetMostDiscussedByPersonId(
+            person.Id,
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(25, result.Count);
+        Assert.DoesNotContain(result, topic => topic.Name == "Topic 26");
+    }
+
+    #endregion
+
     #region GetByPersonId
 
     [Theory]
@@ -564,4 +655,30 @@ public class TopicServiceTests : BaseServiceIntegrationTest, IClassFixture<Servi
     }
 
     #endregion
+
+    private async Task<EpisodeEntity> CreateEpisodeAsync(int showId, int patreonId, string title)
+    {
+        PatreonPostEntity post = new()
+        {
+            PatreonId = patreonId,
+            Title = $"Post {patreonId}",
+            Link = $"https://patreon.com/{patreonId}",
+            Summary = $"Summary {patreonId}",
+            Published = DateTimeOffset.UtcNow,
+            AudioUrl = $"https://audio.com/{patreonId}",
+            ShowId = showId
+        };
+
+        EpisodeEntity episode = new()
+        {
+            Title = title,
+            ReleaseDateUtc = DateTimeOffset.UtcNow,
+            PatreonPost = post,
+            ShowId = showId
+        };
+
+        await InsertSingleInstanceOfEntityAsync(episode);
+
+        return episode;
+    }
 }


### PR DESCRIPTION
- Implemented GetMostDiscussedTopicsByPersonId method in ILsmArchiveClientService and LsmArchiveClientService.
- Added corresponding endpoint in PersonEndpoints for fetching most discussed topics.
- Created GetMostDiscussedByPersonId method in ITopicService and TopicService to handle business logic.
- Updated PersonPage to display most discussed topics in a new tab.
- Added unit tests for the new functionality in LsmArchiveClientServiceTests, PersonEndpointTests, and TopicServiceTests.
- Introduced MostDiscussedTopic model to represent the response structure.