### PR TITLE
Add episode timeline feature to person page with sorting options

### DIFF
--- a/src/TheLsmArchive.ApiClient/Services/Abstractions/ILsmArchiveClientService.cs
+++ b/src/TheLsmArchive.ApiClient/Services/Abstractions/ILsmArchiveClientService.cs
@@ -51,15 +51,17 @@ public interface ILsmArchiveClientService
         CancellationToken cancellationToken);
 
     /// <summary>
-    /// Gets episodes associated with a person by their ID.
+    /// Gets episode timeline entries associated with a person by their ID.
     /// </summary>
     /// <param name="personId">The person ID.</param>
     /// <param name="pagedRequest">The paged request.</param>
+    /// <param name="sortDescending">Whether to sort by release date descending (newest first).</param>
     /// <param name="cancellationToken">The cancellation token.</param>
-    /// <returns>The <see cref="Result{T}"/> of <see cref="PagedResponse{T}"/> of <see cref="Episode"/>.</returns>
-    public Task<Result<PagedResponse<Episode>>> GetEpisodesByPersonId(
+    /// <returns>The <see cref="Result{T}"/> of <see cref="PagedResponse{T}"/> of <see cref="PersonTimelineEntry"/>.</returns>
+    public Task<Result<PagedResponse<PersonTimelineEntry>>> GetEpisodesByPersonId(
         int personId,
         PagedItemRequest pagedRequest,
+        bool sortDescending,
         CancellationToken cancellationToken);
 
     /// <summary>

--- a/src/TheLsmArchive.ApiClient/Services/LsmArchiveClientService.cs
+++ b/src/TheLsmArchive.ApiClient/Services/LsmArchiveClientService.cs
@@ -167,9 +167,10 @@ public class LsmArchiveClientService : ILsmArchiveClientService
     /// <inheritdoc />
     /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="personId"/> is negative.</exception>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="pagedRequest"/> is null.</exception>
-    public Task<Result<PagedResponse<Episode>>> GetEpisodesByPersonId(
+    public Task<Result<PagedResponse<PersonTimelineEntry>>> GetEpisodesByPersonId(
         int personId,
         PagedItemRequest pagedRequest,
+        bool sortDescending,
         CancellationToken cancellationToken)
     {
         ArgumentOutOfRangeException.ThrowIfNegative(personId);
@@ -177,11 +178,13 @@ public class LsmArchiveClientService : ILsmArchiveClientService
 
         _logger.LogInformation("Getting episodes for person with ID: {PersonId}", personId);
 
+        string queryString = $"{pagedRequest.ToQueryString()}&sortDescending={sortDescending}";
+
         HttpRequestMessage requestMessage = BuildGetRequestMessageFor(
             $"{PersonRoute}/{personId}/episodes",
-            pagedRequest.ToQueryString());
+            queryString);
 
-        return ExecuteRequestAsync<PagedResponse<Episode>>(
+        return ExecuteRequestAsync<PagedResponse<PersonTimelineEntry>>(
             requestMessage,
             hasContent: result => result is not null && result.Items.Count > 0,
             cancellationToken

--- a/src/TheLsmArchive.Models/Response/PersonTimelineEntry.cs
+++ b/src/TheLsmArchive.Models/Response/PersonTimelineEntry.cs
@@ -1,0 +1,16 @@
+namespace TheLsmArchive.Models.Response;
+
+/// <summary>
+/// Represents a single entry in a person's episode timeline.
+/// </summary>
+/// <param name="EpisodeId">The unique identifier of the episode.</param>
+/// <param name="Title">The title of the episode.</param>
+/// <param name="ReleaseDate">The release date of the episode.</param>
+/// <param name="PatreonPostLink">The link to the Patreon post for the episode.</param>
+/// <param name="Topics">The topics discussed in this episode.</param>
+public record PersonTimelineEntry(
+    int EpisodeId,
+    string Title,
+    DateOnly ReleaseDate,
+    string PatreonPostLink,
+    List<Topic> Topics);

--- a/src/TheLsmArchive.Web.Api/Features/Episodes/EpisodeService.cs
+++ b/src/TheLsmArchive.Web.Api/Features/Episodes/EpisodeService.cs
@@ -53,9 +53,10 @@ public sealed class EpisodeService : IEpisodeService
     /// <inheritdoc />
     /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="id"/> is negative or zero.</exception>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="pagedRequest"/> is null.</exception>
-    public async Task<PagedResponse<Episode>> GetByPersonId(
+    public async Task<PagedResponse<PersonTimelineEntry>> GetByPersonId(
         int id,
         PagedItemRequest pagedRequest,
+        bool sortDescending,
         CancellationToken cancellationToken)
     {
         ArgumentOutOfRangeException.ThrowIfNegativeOrZero(id);
@@ -63,35 +64,40 @@ public sealed class EpisodeService : IEpisodeService
 
         _logger.LogInformation("Getting episodes for person with ID: {Id}", id);
 
-        Expression<Func<PersonEpisodeEntity, Episode>> mapToEpisode =
-            personEpisode => new Episode(
-                Id: personEpisode.Episode.Id,
-                Title: personEpisode.Episode.Title,
-                ReleaseDate: DateOnly.FromDateTime(personEpisode.Episode.ReleaseDateUtc.UtcDateTime),
-                PatreonPostLink: personEpisode.Episode.PatreonPost.Link,
-                SummaryHtml: personEpisode.Episode.PatreonPost.Summary);
-
         IQueryable<PersonEpisodeEntity> baseQuery = _dbContext.PersonEpisodes
             .Include(pe => pe.Episode)
                 .ThenInclude(e => e.PatreonPost)
+            .Include(pe => pe.Episode)
+                .ThenInclude(e => e.TopicEpisodes)
+                    .ThenInclude(te => te.Topic)
             .Where(pe => pe.PersonId == id);
 
         if (!string.IsNullOrWhiteSpace(pagedRequest.SearchTerm))
         {
             baseQuery = baseQuery.Where(pe =>
                 EF.Functions.ILike(pe.Episode.Title, $"%{pagedRequest.SearchTerm}%") ||
-                EF.Functions.ILike(pe.Episode.PatreonPost.Summary, $"%{pagedRequest.SearchTerm}%"));
+                pe.Episode.TopicEpisodes.Any(te => EF.Functions.ILike(te.Topic.Name, $"%{pagedRequest.SearchTerm}%")));
         }
 
         int totalCount = await baseQuery.CountAsync(cancellationToken);
 
-        List<Episode> items = await baseQuery
-            .OrderBy(pe => pe.Episode.Title)
+        IOrderedQueryable<PersonEpisodeEntity> orderedQuery = sortDescending
+            ? baseQuery.OrderByDescending(pe => pe.Episode.ReleaseDateUtc)
+            : baseQuery.OrderBy(pe => pe.Episode.ReleaseDateUtc);
+
+        List<PersonTimelineEntry> items = await orderedQuery
             .WithPaging(pagedRequest)
-            .Select(mapToEpisode)
+            .Select(pe => new PersonTimelineEntry(
+                EpisodeId: pe.Episode.Id,
+                Title: pe.Episode.Title,
+                ReleaseDate: DateOnly.FromDateTime(pe.Episode.ReleaseDateUtc.DateTime),
+                PatreonPostLink: pe.Episode.PatreonPost.Link,
+                Topics: pe.Episode.TopicEpisodes
+                    .Select(te => new Topic(te.Topic.Id, te.Topic.Name))
+                    .ToList()))
             .ToListAsync(cancellationToken);
 
-        return new PagedResponse<Episode>(items, totalCount, pagedRequest.PageNumber, pagedRequest.PageSize);
+        return new PagedResponse<PersonTimelineEntry>(items, totalCount, pagedRequest.PageNumber, pagedRequest.PageSize);
     }
 
     /// <inheritdoc />

--- a/src/TheLsmArchive.Web.Api/Features/Episodes/IEpisodeService.cs
+++ b/src/TheLsmArchive.Web.Api/Features/Episodes/IEpisodeService.cs
@@ -16,15 +16,17 @@ public interface IEpisodeService
          CancellationToken cancellationToken);
 
     /// <summary>
-    /// Gets episodes by a person's identifier.
+    /// Gets timeline entries for episodes by a person's identifier.
     /// </summary>
     /// <param name="id">The person's identifier.</param>
     /// <param name="pagedRequest">The paged request.</param>
+    /// <param name="sortDescending">Whether to sort by release date descending (newest first).</param>
     /// <param name="cancellationToken">The cancellation token.</param>
-    /// <returns>A paged response of episodes associated with the person.</returns>
-    public Task<PagedResponse<Episode>> GetByPersonId(
+    /// <returns>A paged response of person timeline entries associated with the person.</returns>
+    public Task<PagedResponse<PersonTimelineEntry>> GetByPersonId(
         int id,
         PagedItemRequest pagedRequest,
+        bool sortDescending,
         CancellationToken cancellationToken);
 
     /// <summary>

--- a/src/TheLsmArchive.Web.Api/Features/Persons/PersonEndpoints.cs
+++ b/src/TheLsmArchive.Web.Api/Features/Persons/PersonEndpoints.cs
@@ -51,8 +51,8 @@ internal static class PersonEndpoints
             person.MapGet("/{id:int}/episodes", GetEpisodesByPersonId)
                 .WithName(nameof(GetEpisodesByPersonId))
                 .WithSummary("Gets episodes associated with a specific person.")
-                .WithDescription("Retrieves a paginated list of episodes that are associated with the specified person ID.")
-                .Produces<Ok<PagedResponse<Episode>>>()
+                .WithDescription("Retrieves a paginated timeline of episodes that are associated with the specified person ID.")
+                .Produces<Ok<PagedResponse<PersonTimelineEntry>>>()
                 .Produces<BadRequest>();
 
             person.MapGet("/{id:int}/episodes/latest", GetLatestEpisodeByPersonId)
@@ -114,13 +114,14 @@ internal static class PersonEndpoints
         return TypedResults.Ok(topics);
     }
 
-    private static async Task<Ok<PagedResponse<Episode>>> GetEpisodesByPersonId(
+    private static async Task<Ok<PagedResponse<PersonTimelineEntry>>> GetEpisodesByPersonId(
         [FromRoute] int id,
         [AsParameters] PagedItemRequest pagedRequest,
-        [FromServices] IEpisodeService episodeService,
-        CancellationToken cancellationToken)
+        [FromQuery] bool sortDescending = true,
+        [FromServices] IEpisodeService episodeService = default!,
+        CancellationToken cancellationToken = default)
     {
-        PagedResponse<Episode> episodes = await episodeService.GetByPersonId(id, pagedRequest, cancellationToken);
+        PagedResponse<PersonTimelineEntry> episodes = await episodeService.GetByPersonId(id, pagedRequest, sortDescending, cancellationToken);
         return TypedResults.Ok(episodes);
     }
 

--- a/src/TheLsmArchive.Web.Frontend/Pages/PersonPage.razor
+++ b/src/TheLsmArchive.Web.Frontend/Pages/PersonPage.razor
@@ -211,35 +211,61 @@
         </MudItem>
 
         <MudItem xs="12">
-            <SectionHeader Icon="@Icons.Material.Filled.Headphones" Color="Color.Primary" Title="Episodes" />
-            <MudTextField
-                T="string"
-                Variant="Variant.Outlined"
-                Placeholder="Search episodes..."
-                Adornment="Adornment.Start"
-                AdornmentIcon="@Icons.Material.Filled.Search"
-                AdornmentColor="Color.Primary"
-                Value="_episodeSearchTerm"
-                ValueChanged="OnEpisodeSearchTermChanged"
-                Immediate="true"
-                FullWidth="true"
-                Clearable="true"
-                Margin="Margin.Dense"
-                Class="mb-4" />
-            @if (_isLoadingEpisodes)
-            {
-                <MudProgressLinear Color="Color.Primary" Indeterminate="true" Class="mb-4" />
-            }
+            <MudStack Row="true" AlignItems="AlignItems.Center" Justify="Justify.SpaceBetween" Class="mb-4">
+                <SectionHeader Icon="@Icons.Material.Filled.Timeline" Color="Color.Primary" Title="Timeline"/>
+                <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2">
+                    <MudTextField T="string"
+                                  Variant="Variant.Outlined"
+                                  Placeholder="Search episodes..."
+                                  Adornment="Adornment.Start"
+                                  AdornmentIcon="@Icons.Material.Filled.Search"
+                                  AdornmentColor="Color.Primary"
+                                  Value="_episodeSearchTerm"
+                                  ValueChanged="OnEpisodeSearchTermChanged"
+                                  Immediate="true"
+                                  Clearable="true"
+                                  Margin="Margin.Dense"
+                                  Style="max-width: 300px;"/>
+                    <MudTooltip Text="@(_sortDescending ? "Showing newest first" : "Showing oldest first")">
+                        <MudIconButton Icon="@(_sortDescending ? Icons.Material.Filled.ArrowDownward : Icons.Material.Filled.ArrowUpward)"
+                                       Color="Color.Primary"
+                                       OnClick="ToggleSort"/>
+                    </MudTooltip>
+                </MudStack>
+            </MudStack>
             @if (_episodesResponse is { Items.Count: > 0 })
             {
-                <MudGrid Spacing="3">
-                    @foreach (var episode in _episodesResponse.Items)
+                <MudTimeline TimelineOrientation="TimelineOrientation.Vertical" TimelinePosition="TimelinePosition.Start">
+                    @foreach (var entry in _episodesResponse.Items)
                     {
-                        <MudItem xs="12" sm="6" md="4" lg="3" Class="d-flex">
-                            <EpisodeCard Episode="episode" />
-                        </MudItem>
+                        <MudTimelineItem Color="Color.Primary" Size="Size.Small" Icon="@Icons.Material.Filled.Headphones">
+                            <ChildContent>
+                                <MudCard Class="card-hover hover-primary entity-card clickable-card" Elevation="2">
+                                    <MudCardContent @onclick='() => NavigationManager.NavigateTo($"/Episode/{entry.EpisodeId}")'>
+                                        <MudText Typo="Typo.body1" Class="fw-bold">@entry.Title</MudText>
+                                        <MudText Typo="Typo.body2" Color="Color.Primary" Class="mb-2">@entry.ReleaseDate.ToLongDateString()</MudText>
+                                        @if (entry.Topics.Count > 0)
+                                        {
+                                            <MudStack Row="true" Class="flex-wrap" Spacing="1">
+                                                @foreach (var topic in entry.Topics)
+                                                {
+                                                    <MudChip T="string"
+                                                             Icon="@Icons.Material.Filled.Tag"
+                                                             Color="Color.Tertiary"
+                                                             Variant="Variant.Text"
+                                                             Size="Size.Small"
+                                                             OnClick="@(() => NavigationManager.NavigateTo($"/Topic/{topic.Id}"))">
+                                                        @topic.Name
+                                                    </MudChip>
+                                                }
+                                            </MudStack>
+                                        }
+                                    </MudCardContent>
+                                </MudCard>
+                            </ChildContent>
+                        </MudTimelineItem>
                     }
-                </MudGrid>
+                </MudTimeline>
                 @if (_episodesResponse.TotalPages > 1)
                 {
                     <MudStack Row="true" Justify="Justify.Center" Class="mt-4">
@@ -251,19 +277,13 @@
                                        BoundaryCount="1"
                                        MiddleCount="3"
                                        ShowFirstButton="true"
-                                       ShowLastButton="true" />
+                                       ShowLastButton="true"/>
                     </MudStack>
                 }
             }
             else if (_episodesResponse is not null)
             {
-                <MudText Typo="Typo.body2" Class="mt-2" Style="opacity: 0.6;">No episodes found.</MudText>
-            }
-            else
-            {
-                <MudContainer Class="d-flex justify-center py-4">
-                    <MudProgressCircular Indeterminate="true" Color="Color.Primary" Size="Size.Small" />
-                </MudContainer>
+                <MudText Typo="Typo.body1" Color="Color.Default" Class="mt-4">No episodes found.</MudText>
             }
         </MudItem>
     }
@@ -288,7 +308,8 @@
 </MudGrid>
 
 @code {
-    private const int PageSize = 50;
+    private const int EpisodePageSize = 25;
+    private const int TopicPageSize = 50;
     private const int SearchDebounceMs = 350;
     private const int MostDiscussedTopicsTabIndex = 0;
 
@@ -300,14 +321,14 @@
     private Episode? _latestEpisode;
     private List<MostDiscussedTopic>? _mostDiscussedTopics;
     private PagedResponse<Topic>? _topicsResponse;
-    private PagedResponse<Episode>? _episodesResponse;
+    private PagedResponse<PersonTimelineEntry>? _episodesResponse;
     private int _activeTopicsTabIndex = MostDiscussedTopicsTabIndex;
     private int _currentTopicPage = 1;
     private int _currentEpisodePage = 1;
     private string _topicSearchTerm = string.Empty;
     private string _episodeSearchTerm = string.Empty;
     private bool _isLoadingTopics;
-    private bool _isLoadingEpisodes;
+    private bool _sortDescending = true;
     private CancellationTokenSource? _topicSearchDebounceCts;
     private CancellationTokenSource? _episodeSearchDebounceCts;
 
@@ -362,7 +383,6 @@
     {
         _episodeSearchTerm = value;
         _currentEpisodePage = 1;
-        _isLoadingEpisodes = true;
 
         _episodeSearchDebounceCts?.Cancel();
         _episodeSearchDebounceCts = new CancellationTokenSource();
@@ -378,7 +398,6 @@
         }
 
         await GetPersonEpisodes(_currentEpisodePage, token);
-        _isLoadingEpisodes = false;
         StateHasChanged();
     }
 
@@ -456,7 +475,7 @@
     private async Task GetPersonTopics(int pageNumber, CancellationToken cancellationToken)
     {
         string? searchTerm = string.IsNullOrWhiteSpace(_topicSearchTerm) ? null : _topicSearchTerm;
-        PagedItemRequest pagedRequest = new(pageNumber, PageSize, searchTerm);
+        PagedItemRequest pagedRequest = new(pageNumber, TopicPageSize, searchTerm);
         var personTopicsResult = await ClientService.GetTopicsByPersonId(Id, pagedRequest, cancellationToken);
 
         await HandleResult(
@@ -468,7 +487,7 @@
             },
             () =>
             {
-                _topicsResponse = new PagedResponse<Topic>([], 0, pageNumber, PageSize);
+                _topicsResponse = new PagedResponse<Topic>([], 0, pageNumber, TopicPageSize);
                 return Task.CompletedTask;
             });
     }
@@ -494,8 +513,8 @@
     private async Task GetPersonEpisodes(int pageNumber, CancellationToken cancellationToken)
     {
         string? searchTerm = string.IsNullOrWhiteSpace(_episodeSearchTerm) ? null : _episodeSearchTerm;
-        PagedItemRequest pagedRequest = new(pageNumber, PageSize, searchTerm);
-        var personEpisodesResult = await ClientService.GetEpisodesByPersonId(Id, pagedRequest, cancellationToken);
+        PagedItemRequest pagedRequest = new(pageNumber, EpisodePageSize, searchTerm);
+        var personEpisodesResult = await ClientService.GetEpisodesByPersonId(Id, pagedRequest, _sortDescending, cancellationToken);
 
         await HandleResult(
             personEpisodesResult,
@@ -506,9 +525,18 @@
             },
             () =>
             {
-                _episodesResponse = new PagedResponse<Episode>([], 0, pageNumber, PageSize);
+                _episodesResponse = new PagedResponse<PersonTimelineEntry>([], 0, pageNumber, EpisodePageSize);
                 return Task.CompletedTask;
             });
+    }
+
+    private async Task ToggleSort()
+    {
+        _sortDescending = !_sortDescending;
+        _currentEpisodePage = 1;
+        using CancellationTokenSource cts = new();
+        await GetPersonEpisodes(_currentEpisodePage, cts.Token);
+        StateHasChanged();
     }
 
     public void Dispose()

--- a/tests/TheLsmArchive.ApiClient.Tests/LsmArchiveClientServiceTests.cs
+++ b/tests/TheLsmArchive.ApiClient.Tests/LsmArchiveClientServiceTests.cs
@@ -308,7 +308,7 @@ public class LsmArchiveClientServiceTests
         LsmArchiveClientService service = CreateService(handler);
 
         await Assert.ThrowsAsync<ArgumentOutOfRangeException>(
-            () => service.GetEpisodesByPersonId(-1, new PagedItemRequest(), CancellationToken.None));
+            () => service.GetEpisodesByPersonId(-1, new PagedItemRequest(), true, CancellationToken.None));
     }
 
     [Fact]
@@ -318,7 +318,7 @@ public class LsmArchiveClientServiceTests
         LsmArchiveClientService service = CreateService(handler);
 
         await Assert.ThrowsAsync<ArgumentNullException>(
-            () => service.GetEpisodesByPersonId(1, null!, CancellationToken.None));
+            () => service.GetEpisodesByPersonId(1, null!, true, CancellationToken.None));
     }
 
     [Fact]

--- a/tests/TheLsmArchive.Web.Api.Tests/Features/Episodes/EpisodeServiceTests.cs
+++ b/tests/TheLsmArchive.Web.Api.Tests/Features/Episodes/EpisodeServiceTests.cs
@@ -224,7 +224,7 @@ public class EpisodeServiceTests : BaseServiceIntegrationTest, IClassFixture<Ser
     {
 #pragma warning disable IDE0022
         await Assert.ThrowsAsync<ArgumentOutOfRangeException>(() =>
-            _episodeService.GetByPersonId(id, new PagedItemRequest(), TestContext.Current.CancellationToken));
+            _episodeService.GetByPersonId(id, new PagedItemRequest(), true, TestContext.Current.CancellationToken));
 #pragma warning restore IDE0022
     }
 
@@ -233,7 +233,7 @@ public class EpisodeServiceTests : BaseServiceIntegrationTest, IClassFixture<Ser
     {
 #pragma warning disable IDE0022
         await Assert.ThrowsAsync<ArgumentNullException>(() =>
-            _episodeService.GetByPersonId(1, null!, TestContext.Current.CancellationToken));
+            _episodeService.GetByPersonId(1, null!, true, TestContext.Current.CancellationToken));
 #pragma warning restore IDE0022
     }
 
@@ -245,8 +245,8 @@ public class EpisodeServiceTests : BaseServiceIntegrationTest, IClassFixture<Ser
         await InsertSingleInstanceOfEntityAsync(person);
 
         // Act
-        PagedResponse<Episode> result = await _episodeService.GetByPersonId(
-            person.Id, new PagedItemRequest(), TestContext.Current.CancellationToken);
+        PagedResponse<PersonTimelineEntry> result = await _episodeService.GetByPersonId(
+            person.Id, new PagedItemRequest(), true, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Empty(result.Items);
@@ -254,7 +254,7 @@ public class EpisodeServiceTests : BaseServiceIntegrationTest, IClassFixture<Ser
     }
 
     [Fact]
-    public async Task GetByPersonId_WithAssociatedEpisodes_ReturnsPagedEpisodes()
+    public async Task GetByPersonId_WithAssociatedEpisodes_ReturnsPagedEntries()
     {
         // Arrange
         ShowEntity show = new() { Name = "Show 1" };
@@ -294,8 +294,8 @@ public class EpisodeServiceTests : BaseServiceIntegrationTest, IClassFixture<Ser
         await InsertSingleInstanceOfEntityAsync(pe2);
 
         // Act
-        PagedResponse<Episode> result = await _episodeService.GetByPersonId(
-            person.Id, new PagedItemRequest(), TestContext.Current.CancellationToken);
+        PagedResponse<PersonTimelineEntry> result = await _episodeService.GetByPersonId(
+            person.Id, new PagedItemRequest(), true, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Equal(2, result.TotalCount);
@@ -345,8 +345,8 @@ public class EpisodeServiceTests : BaseServiceIntegrationTest, IClassFixture<Ser
         await InsertSingleInstanceOfEntityAsync(pe2);
 
         // Act — search by title
-        PagedResponse<Episode> result = await _episodeService.GetByPersonId(
-            person.Id, new PagedItemRequest(SearchTerm: "Gaming"), TestContext.Current.CancellationToken);
+        PagedResponse<PersonTimelineEntry> result = await _episodeService.GetByPersonId(
+            person.Id, new PagedItemRequest(SearchTerm: "Gaming"), true, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Equal(1, result.TotalCount);
@@ -368,9 +368,9 @@ public class EpisodeServiceTests : BaseServiceIntegrationTest, IClassFixture<Ser
         PatreonPostEntity post2 = new() { PatreonId = 502, Title = "Post 502", Link = "https://patreon.com/502", Summary = "S", Published = DateTimeOffset.UtcNow, AudioUrl = "https://audio.com/502", ShowId = show.Id };
         PatreonPostEntity post3 = new() { PatreonId = 503, Title = "Post 503", Link = "https://patreon.com/503", Summary = "S", Published = DateTimeOffset.UtcNow, AudioUrl = "https://audio.com/503", ShowId = show.Id };
 
-        EpisodeEntity ep1 = new() { Title = "Alpha", ReleaseDateUtc = DateTimeOffset.UtcNow, PatreonPost = post1, ShowId = show.Id };
-        EpisodeEntity ep2 = new() { Title = "Beta", ReleaseDateUtc = DateTimeOffset.UtcNow, PatreonPost = post2, ShowId = show.Id };
-        EpisodeEntity ep3 = new() { Title = "Gamma", ReleaseDateUtc = DateTimeOffset.UtcNow, PatreonPost = post3, ShowId = show.Id };
+        EpisodeEntity ep1 = new() { Title = "Alpha", ReleaseDateUtc = new DateTimeOffset(2024, 1, 1, 0, 0, 0, TimeSpan.Zero), PatreonPost = post1, ShowId = show.Id };
+        EpisodeEntity ep2 = new() { Title = "Beta", ReleaseDateUtc = new DateTimeOffset(2024, 2, 1, 0, 0, 0, TimeSpan.Zero), PatreonPost = post2, ShowId = show.Id };
+        EpisodeEntity ep3 = new() { Title = "Gamma", ReleaseDateUtc = new DateTimeOffset(2024, 3, 1, 0, 0, 0, TimeSpan.Zero), PatreonPost = post3, ShowId = show.Id };
 
         await InsertSingleInstanceOfEntityAsync(ep1);
         await InsertSingleInstanceOfEntityAsync(ep2);
@@ -383,14 +383,152 @@ public class EpisodeServiceTests : BaseServiceIntegrationTest, IClassFixture<Ser
         await InsertSingleInstanceOfEntityAsync(pe2);
         await InsertSingleInstanceOfEntityAsync(pe3);
 
-        // Act — page 2, size 1 (ordered by title: Alpha, Beta, Gamma)
-        PagedResponse<Episode> result = await _episodeService.GetByPersonId(
-            person.Id, new PagedItemRequest(PageNumber: 2, PageSize: 1), TestContext.Current.CancellationToken);
+        // Act — page 2, size 1, descending (ordered by date desc: Gamma, Beta, Alpha)
+        PagedResponse<PersonTimelineEntry> result = await _episodeService.GetByPersonId(
+            person.Id, new PagedItemRequest(PageNumber: 2, PageSize: 1), true, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Equal(3, result.TotalCount);
         Assert.Single(result.Items);
         Assert.Equal("Beta", result.Items[0].Title);
+    }
+
+    [Fact]
+    public async Task GetByPersonId_SortDescending_ReturnsNewestFirst()
+    {
+        // Arrange
+        ShowEntity show = new() { Name = "Show 1" };
+        await InsertSingleInstanceOfEntityAsync(show);
+
+        PersonEntity person = new() { Name = "Test Person", NormalizedName = "testperson" };
+        await InsertSingleInstanceOfEntityAsync(person);
+
+        PatreonPostEntity post1 = new() { PatreonId = 601, Title = "Post 601", Link = "https://patreon.com/601", Summary = "S", Published = DateTimeOffset.UtcNow, AudioUrl = "https://audio.com/601", ShowId = show.Id };
+        PatreonPostEntity post2 = new() { PatreonId = 602, Title = "Post 602", Link = "https://patreon.com/602", Summary = "S", Published = DateTimeOffset.UtcNow, AudioUrl = "https://audio.com/602", ShowId = show.Id };
+
+        EpisodeEntity older = new() { Title = "Older Episode", ReleaseDateUtc = new DateTimeOffset(2024, 1, 10, 0, 0, 0, TimeSpan.Zero), PatreonPost = post1, ShowId = show.Id };
+        EpisodeEntity newer = new() { Title = "Newer Episode", ReleaseDateUtc = new DateTimeOffset(2024, 6, 15, 0, 0, 0, TimeSpan.Zero), PatreonPost = post2, ShowId = show.Id };
+
+        await InsertSingleInstanceOfEntityAsync(older);
+        await InsertSingleInstanceOfEntityAsync(newer);
+
+        await InsertSingleInstanceOfEntityAsync(new PersonEpisodeEntity { PersonId = person.Id, EpisodeId = older.Id });
+        await InsertSingleInstanceOfEntityAsync(new PersonEpisodeEntity { PersonId = person.Id, EpisodeId = newer.Id });
+
+        // Act
+        PagedResponse<PersonTimelineEntry> result = await _episodeService.GetByPersonId(
+            person.Id, new PagedItemRequest(), true, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(2, result.Items.Count);
+        Assert.Equal("Newer Episode", result.Items[0].Title);
+        Assert.Equal("Older Episode", result.Items[1].Title);
+    }
+
+    [Fact]
+    public async Task GetByPersonId_SortAscending_ReturnsOldestFirst()
+    {
+        // Arrange
+        ShowEntity show = new() { Name = "Show 1" };
+        await InsertSingleInstanceOfEntityAsync(show);
+
+        PersonEntity person = new() { Name = "Test Person", NormalizedName = "testperson" };
+        await InsertSingleInstanceOfEntityAsync(person);
+
+        PatreonPostEntity post1 = new() { PatreonId = 701, Title = "Post 701", Link = "https://patreon.com/701", Summary = "S", Published = DateTimeOffset.UtcNow, AudioUrl = "https://audio.com/701", ShowId = show.Id };
+        PatreonPostEntity post2 = new() { PatreonId = 702, Title = "Post 702", Link = "https://patreon.com/702", Summary = "S", Published = DateTimeOffset.UtcNow, AudioUrl = "https://audio.com/702", ShowId = show.Id };
+
+        EpisodeEntity older = new() { Title = "Older Episode", ReleaseDateUtc = new DateTimeOffset(2024, 1, 10, 0, 0, 0, TimeSpan.Zero), PatreonPost = post1, ShowId = show.Id };
+        EpisodeEntity newer = new() { Title = "Newer Episode", ReleaseDateUtc = new DateTimeOffset(2024, 6, 15, 0, 0, 0, TimeSpan.Zero), PatreonPost = post2, ShowId = show.Id };
+
+        await InsertSingleInstanceOfEntityAsync(older);
+        await InsertSingleInstanceOfEntityAsync(newer);
+
+        await InsertSingleInstanceOfEntityAsync(new PersonEpisodeEntity { PersonId = person.Id, EpisodeId = older.Id });
+        await InsertSingleInstanceOfEntityAsync(new PersonEpisodeEntity { PersonId = person.Id, EpisodeId = newer.Id });
+
+        // Act
+        PagedResponse<PersonTimelineEntry> result = await _episodeService.GetByPersonId(
+            person.Id, new PagedItemRequest(), false, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(2, result.Items.Count);
+        Assert.Equal("Older Episode", result.Items[0].Title);
+        Assert.Equal("Newer Episode", result.Items[1].Title);
+    }
+
+    [Fact]
+    public async Task GetByPersonId_IncludesTopicsInEntries()
+    {
+        // Arrange
+        ShowEntity show = new() { Name = "Show 1" };
+        await InsertSingleInstanceOfEntityAsync(show);
+
+        PersonEntity person = new() { Name = "Test Person", NormalizedName = "testperson" };
+        await InsertSingleInstanceOfEntityAsync(person);
+
+        TopicEntity topic1 = new() { Name = "Topic Alpha", NormalizedName = "topicalpha" };
+        TopicEntity topic2 = new() { Name = "Topic Beta", NormalizedName = "topicbeta" };
+        await InsertSingleInstanceOfEntityAsync(topic1);
+        await InsertSingleInstanceOfEntityAsync(topic2);
+
+        PatreonPostEntity post = new() { PatreonId = 801, Title = "Post 801", Link = "https://patreon.com/801", Summary = "S", Published = DateTimeOffset.UtcNow, AudioUrl = "https://audio.com/801", ShowId = show.Id };
+
+        EpisodeEntity episode = new() { Title = "Episode With Topics", ReleaseDateUtc = DateTimeOffset.UtcNow, PatreonPost = post, ShowId = show.Id };
+        await InsertSingleInstanceOfEntityAsync(episode);
+
+        await InsertSingleInstanceOfEntityAsync(new PersonEpisodeEntity { PersonId = person.Id, EpisodeId = episode.Id });
+        await InsertSingleInstanceOfEntityAsync(new TopicEpisodeEntity { TopicId = topic1.Id, EpisodeId = episode.Id });
+        await InsertSingleInstanceOfEntityAsync(new TopicEpisodeEntity { TopicId = topic2.Id, EpisodeId = episode.Id });
+
+        // Act
+        PagedResponse<PersonTimelineEntry> result = await _episodeService.GetByPersonId(
+            person.Id, new PagedItemRequest(), true, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Single(result.Items);
+        Assert.Equal(2, result.Items[0].Topics.Count);
+        Assert.Contains(result.Items[0].Topics, t => t.Name == "Topic Alpha");
+        Assert.Contains(result.Items[0].Topics, t => t.Name == "Topic Beta");
+    }
+
+    [Fact]
+    public async Task GetByPersonId_WithSearchTermMatchingTopicName_FiltersResults()
+    {
+        // Arrange
+        ShowEntity show = new() { Name = "Show 1" };
+        await InsertSingleInstanceOfEntityAsync(show);
+
+        PersonEntity person = new() { Name = "Test Person", NormalizedName = "testperson" };
+        await InsertSingleInstanceOfEntityAsync(person);
+
+        TopicEntity gamingTopic = new() { Name = "Gaming", NormalizedName = "gaming" };
+        TopicEntity cookingTopic = new() { Name = "Cooking", NormalizedName = "cooking" };
+        await InsertSingleInstanceOfEntityAsync(gamingTopic);
+        await InsertSingleInstanceOfEntityAsync(cookingTopic);
+
+        PatreonPostEntity post1 = new() { PatreonId = 901, Title = "Post 901", Link = "https://patreon.com/901", Summary = "S", Published = DateTimeOffset.UtcNow, AudioUrl = "https://audio.com/901", ShowId = show.Id };
+        PatreonPostEntity post2 = new() { PatreonId = 902, Title = "Post 902", Link = "https://patreon.com/902", Summary = "S", Published = DateTimeOffset.UtcNow, AudioUrl = "https://audio.com/902", ShowId = show.Id };
+
+        EpisodeEntity ep1 = new() { Title = "Episode One", ReleaseDateUtc = DateTimeOffset.UtcNow, PatreonPost = post1, ShowId = show.Id };
+        EpisodeEntity ep2 = new() { Title = "Episode Two", ReleaseDateUtc = DateTimeOffset.UtcNow, PatreonPost = post2, ShowId = show.Id };
+
+        await InsertSingleInstanceOfEntityAsync(ep1);
+        await InsertSingleInstanceOfEntityAsync(ep2);
+
+        await InsertSingleInstanceOfEntityAsync(new PersonEpisodeEntity { PersonId = person.Id, EpisodeId = ep1.Id });
+        await InsertSingleInstanceOfEntityAsync(new PersonEpisodeEntity { PersonId = person.Id, EpisodeId = ep2.Id });
+        await InsertSingleInstanceOfEntityAsync(new TopicEpisodeEntity { TopicId = gamingTopic.Id, EpisodeId = ep1.Id });
+        await InsertSingleInstanceOfEntityAsync(new TopicEpisodeEntity { TopicId = cookingTopic.Id, EpisodeId = ep2.Id });
+
+        // Act — search by topic name
+        PagedResponse<PersonTimelineEntry> result = await _episodeService.GetByPersonId(
+            person.Id, new PagedItemRequest(SearchTerm: "Gaming"), true, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(1, result.TotalCount);
+        Assert.Single(result.Items);
+        Assert.Equal("Episode One", result.Items[0].Title);
     }
 
     #endregion

--- a/tests/TheLsmArchive.Web.Api.Tests/Features/Persons/PersonEndpointTests.cs
+++ b/tests/TheLsmArchive.Web.Api.Tests/Features/Persons/PersonEndpointTests.cs
@@ -142,10 +142,10 @@ public class PersonEndpointTests : IClassFixture<CustomWebApplicationFactory>
     public async Task GetEpisodesByPersonId_ReturnsOk()
     {
         // Arrange
-        PagedResponse<Episode> expected = new(
-            [new(1, "Episode A", new DateOnly(2024, 1, 1), "https://patreon.com/1", "Summary")], 1, 1, 50);
+        PagedResponse<PersonTimelineEntry> expected = new(
+            [new(1, "Episode A", new DateOnly(2024, 1, 1), "https://patreon.com/1", [new(1, "Topic A")])], 1, 1, 25);
         _factory.EpisodeServiceMock
-            .Setup(s => s.GetByPersonId(1, It.IsAny<PagedItemRequest>(), It.IsAny<CancellationToken>()))
+            .Setup(s => s.GetByPersonId(1, It.IsAny<PagedItemRequest>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(expected);
 
         // Act


### PR DESCRIPTION
- Updated ILsmArchiveClientService and LsmArchiveClientService to return PersonTimelineEntry instead of Episode.
- Modified EpisodeService and IEpisodeService to support sorting by release date.
- Enhanced PersonEndpoints to retrieve paginated episode timelines.
- Updated PersonPage.razor to display episodes in a timeline format with sorting functionality.
- Added tests for new timeline feature and sorting behavior.